### PR TITLE
Actually fix topic pluralization

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -374,9 +374,9 @@ function updateChannelTopic(loc, channel) {
     // TODO: Perhaps include the day's start time (local time per arcade)
     topic = `${nowString}: 0 players today.`;
   } else if (numPlayers === 0) {
-    const s = (loc.todaysPlayers.length === 1) ? '' : 's';
+    const players = (loc.todaysPlayers.length === 1) ? "Today's only player has" : `All ${loc.todaysPlayers.length} players today have`;
     const timeSinceSeen = timeDifferential(currentTime, loc.todaysPlayers[0].lastTime);
-    topic = `${nowString}: All ${loc.todaysPlayers.length} player${s} today left! :eyes: Last player seen: ${loc.todaysPlayers[0].name} ${timeSinceSeen.str} ago.`;
+    topic = `${nowString}: ${players} left! :eyes: Last player seen: ${loc.todaysPlayers[0].name} ${timeSinceSeen.str} ago.`;
   } else {
     const s = (numPlayers === 1) ? '' : 's';
     topic = `${nowString}: ${numPlayers} player${s} in the last hour. :eyes: <:TFTI:483651827984760842> (${playerNamesTimes.join(', ')})`;


### PR DESCRIPTION
Tested yesterday
```
Updated topic #round1-concord: 11:59 AM: 0 players today.
Updated topic #dnb-dalycity: 11:59 AM: 1 player in the last hour. :eyes: <:TFTI:483651827984760842> (INKH 39m)
Updated topic #round1-sanjose: 11:59 AM: Today's only player has left! :eyes: Last player seen: CRONO 1h 3m ago.
--> D&B Milpitas: Data received @cab1
    > CELPHIED 51415152,HANABEEE 51533542
--> Round1 Concord: Data received @cab1
    > FUTTBIST 51531698,KAIVEX 51504028
--> D&B Daly City: Data received @cab1
    > INKH 51552509,DIMO4LFE 51411388
--> Round1 San Jose: Data received @cab1
    > ANHT0P$$ 51555342,RICHARD 51500817
--> Round1 San Jose: Data received @cab2
    > CRONO 51417024,STYLIZED 51436351
Pruning data. We should see this after we have retrieved all data.
Updated topic #dnb-milpitas: 11:59 AM: 1 player in the last hour. :eyes: <:TFTI:483651827984760842> (CELPHIED 17m)
--> Round1 San Jose: Retrieving data...
--> D&B Milpitas: Retrieving data...
--> D&B Daly City: Retrieving data...
--> Round1 Concord: Retrieving data...
Updated topic #round1-sanjose: 12:00 PM: 0 players today.
Updated topic #dnb-dalycity: 12:00 PM: 0 players today.
Updated topic #round1-concord: 12:00 PM: 0 players today.
Updated topic #dnb-milpitas: 12:00 PM: 0 players today.
```